### PR TITLE
Merge qedges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .tox/
 venv/
 .vscode/
+.DS_Store

--- a/reasoner_util/__init__.py
+++ b/reasoner_util/__init__.py
@@ -164,22 +164,10 @@ def merge_qedges(qedges1: dict, qedges2: dict) -> dict:
     If a key is unique to one edges dict, then the edge will be concatenated to
     the new edges dictionary. If a particular key exists in both messages but
     the values do not match, this will result in an error. """
-    qedges1 = copy.deepcopy(qedges1)
-    new_edges = {}
-
+    new_edges = copy.deepcopy(qedges1)
     for qedge_key, qedge_value in qedges2.items():
-        if qedge_key not in qedges1.keys():
+        if qedge_key not in new_edges:
             new_edges[qedge_key] = copy.deepcopy(qedge_value)
-
-    for qedge_key, qedge_value in qedges1.items():
-        if qedge_key in qedges2.keys():
-            if qedge_value == qedges2[qedge_key]:
-                new_edges[qedge_key] = qedge_value
-            else:
-                raise ValueError(
-                    "Key exists in both messages but values do not match."
-                )
-        else:
-            new_edges[qedge_key] = qedge_value
-
+        elif qedge_value != new_edges[qedge_key]:
+            raise ValueError("Key exists in both messages but values do not match.")
     return new_edges

--- a/reasoner_util/__init__.py
+++ b/reasoner_util/__init__.py
@@ -165,7 +165,7 @@ def merge_qedges(
         merged_message_dict: dict = None
         ) -> dict:
     """Merge qedges: the keys must be the same and the values must be the same.
-    If a key is unique to one message, then the edge will be concatinated to
+    If a key is unique to one message, then the edge will be concatenated to
     the new edges dictionary. If a particular key exists in both messages but
     the values do not match, this will result in an error. """
     if merged_message_dict is None:

--- a/reasoner_util/__init__.py
+++ b/reasoner_util/__init__.py
@@ -159,36 +159,27 @@ def apply_ids(id_map: dict, message_dict: dict) -> None:
                 entry["id"] = id_map[entry["id"]]
 
 
-def merge_qedges(
-        message_dict1: dict,
-        message_dict2: dict,
-        merged_message_dict: dict = None
-        ) -> dict:
+def merge_qedges(qedges1: dict, qedges2: dict) -> dict:
     """Merge qedges: the keys must be the same and the values must be the same.
-    If a key is unique to one message, then the edge will be concatenated to
+    If a key is unique to one edges dict, then the edge will be concatenated to
     the new edges dictionary. If a particular key exists in both messages but
     the values do not match, this will result in an error. """
-    if merged_message_dict is None:
-        merged_message_dict = copy.deepcopy(message_dict1)
+    qedges1 = copy.deepcopy(qedges1)
+    new_edges = {}
 
-    qedges1 = message_dict1["message"]["query_graph"]["edges"]
-    qedges2 = message_dict2["message"]["query_graph"]["edges"]
+    for qedge_key, qedge_value in qedges2.items():
+        if qedge_key not in qedges1.keys():
+            new_edges[qedge_key] = copy.deepcopy(qedge_value)
 
-    new_qedges = {}
-    for qedge in qedges1:
-        if qedge in qedges2.keys():
-            if qedges1[qedge] == qedges2[qedge]:
-                new_qedges[qedge] = qedges1[qedge]
+    for qedge_key, qedge_value in qedges1.items():
+        if qedge_key in qedges2.keys():
+            if qedge_value == qedges2[qedge_key]:
+                new_edges[qedge_key] = qedge_value
             else:
                 raise ValueError(
                     "Key exists in both messages but values do not match."
                 )
         else:
-            new_qedges[qedge] = qedges1[qedge]
+            new_edges[qedge_key] = qedge_value
 
-    for qedge in qedges2:
-        if qedge not in new_qedges.keys():
-            new_qedges[qedge] = qedges2[qedge]
-
-    merged_message_dict["message"]["query_graph"]["edges"] = new_qedges
-    return merged_message_dict
+    return new_edges

--- a/tests/test_jsons/test_merge_qedges1.json
+++ b/tests/test_jsons/test_merge_qedges1.json
@@ -1,38 +1,31 @@
 {
-    "message": {
-      "query_graph": {
-        "nodes": {},
-        "edges": {
-          "e0": {
-            "subject": "n0",
-            "object": "n1",
-            "predicates": [
-              "biolink:related_to"
-            ]
-          },
-          "e1": {
-            "subject": "n1",
-            "object": "n2",
-            "predicates": [
-                "biolink:affects_abundance_of",
-                "biolink:has_phenotype"
-            ]
-          },
-          "e2": {
-            "subject": "n2",
-            "object": "n3",
-            "predicates": [
-                "biolink:affects_expression_of"
-            ]
-          },
-          "eA": {
-            "subject": "n3",
-            "object": "n4",
-            "predicates": [
-                "biolink:has_phenotype"
-            ]
-          }
-        }
-      }
+    "e0": {
+        "subject": "n0",
+        "object": "n1",
+        "predicates": [
+            "biolink:related_to"
+        ]
+    },
+    "e1": {
+        "subject": "n1",
+        "object": "n2",
+        "predicates": [
+            "biolink:affects_abundance_of",
+            "biolink:has_phenotype"
+        ]
+    },
+    "e2": {
+        "subject": "n2",
+        "object": "n3",
+        "predicates": [
+            "biolink:affects_expression_of"
+        ]
+    },
+    "eA": {
+        "subject": "n3",
+        "object": "n4",
+        "predicates": [
+            "biolink:has_phenotype"
+        ]
     }
-  }
+}

--- a/tests/test_jsons/test_merge_qedges1.json
+++ b/tests/test_jsons/test_merge_qedges1.json
@@ -1,0 +1,38 @@
+{
+    "message": {
+      "query_graph": {
+        "nodes": {},
+        "edges": {
+          "e0": {
+            "subject": "n0",
+            "object": "n1",
+            "predicates": [
+              "biolink:related_to"
+            ]
+          },
+          "e1": {
+            "subject": "n1",
+            "object": "n2",
+            "predicates": [
+                "biolink:affects_abundance_of",
+                "biolink:has_phenotype"
+            ]
+          },
+          "e2": {
+            "subject": "n2",
+            "object": "n3",
+            "predicates": [
+                "biolink:affects_expression_of"
+            ]
+          },
+          "eA": {
+            "subject": "n3",
+            "object": "n4",
+            "predicates": [
+                "biolink:has_phenotype"
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/tests/test_jsons/test_merge_qedges2.json
+++ b/tests/test_jsons/test_merge_qedges2.json
@@ -1,0 +1,38 @@
+{
+    "message": {
+      "query_graph": {
+        "nodes": {},
+        "edges": {
+          "e0": {
+            "subject": "n0",
+            "object": "n1",
+            "predicates": [
+              "biolink:related_to"
+            ]
+          },
+          "e1": {
+            "subject": "n1",
+            "object": "n2",
+            "predicates": [
+                "biolink:affects_abundance_of",
+                "biolink:has_phenotype"
+            ]
+          },
+          "e2": {
+            "subject": "n2",
+            "object": "n3",
+            "predicates": [
+                "biolink:affects_expression_of"
+            ]
+          },
+          "eB": {
+            "subject": "n0",
+            "object": "n4",
+            "predicates": [
+                "biolink:related_to"
+            ]
+          }
+        }
+      }
+    }
+  }

--- a/tests/test_jsons/test_merge_qedges2.json
+++ b/tests/test_jsons/test_merge_qedges2.json
@@ -1,38 +1,31 @@
 {
-    "message": {
-      "query_graph": {
-        "nodes": {},
-        "edges": {
-          "e0": {
-            "subject": "n0",
-            "object": "n1",
-            "predicates": [
-              "biolink:related_to"
-            ]
-          },
-          "e1": {
-            "subject": "n1",
-            "object": "n2",
-            "predicates": [
-                "biolink:affects_abundance_of",
-                "biolink:has_phenotype"
-            ]
-          },
-          "e2": {
-            "subject": "n2",
-            "object": "n3",
-            "predicates": [
-                "biolink:affects_expression_of"
-            ]
-          },
-          "eB": {
-            "subject": "n0",
-            "object": "n4",
-            "predicates": [
-                "biolink:related_to"
-            ]
-          }
-        }
-      }
+    "e0": {
+        "subject": "n0",
+        "object": "n1",
+        "predicates": [
+            "biolink:related_to"
+        ]
+    },
+    "e1": {
+        "subject": "n1",
+        "object": "n2",
+        "predicates": [
+            "biolink:affects_abundance_of",
+            "biolink:has_phenotype"
+        ]
+    },
+    "e2": {
+        "subject": "n2",
+        "object": "n3",
+        "predicates": [
+            "biolink:affects_expression_of"
+        ]
+    },
+    "eB": {
+        "subject": "n0",
+        "object": "n4",
+        "predicates": [
+            "biolink:related_to"
+        ]
     }
-  }
+}

--- a/tests/test_jsons/test_merge_qedges2_w_error.json
+++ b/tests/test_jsons/test_merge_qedges2_w_error.json
@@ -1,0 +1,30 @@
+{
+    "e0": {
+        "subject": "n0",
+        "object": "n1",
+        "predicates": [
+            "biolink:related_to"
+        ]
+    },
+    "e1": {
+        "subject": "n1",
+        "object": "n2",
+        "predicates": [
+            "biolink:related_to"
+        ]
+    },
+    "e2": {
+        "subject": "n2",
+        "object": "n3",
+        "predicates": [
+            "biolink:affects_expression_of"
+        ]
+    },
+    "eB": {
+        "subject": "n0",
+        "object": "n4",
+        "predicates": [
+            "biolink:related_to"
+        ]
+    }
+}

--- a/tests/test_jsons/test_merge_qedges_success.json
+++ b/tests/test_jsons/test_merge_qedges_success.json
@@ -1,0 +1,45 @@
+{
+    "message": {
+      "query_graph": {
+        "nodes": {},
+        "edges": {
+            "e0": {
+                "subject": "n0",
+                "object": "n1",
+                "predicates": [
+                  "biolink:related_to"
+                ]
+              },
+              "e1": {
+                "subject": "n1",
+                "object": "n2",
+                "predicates": [
+                    "biolink:affects_abundance_of",
+                    "biolink:has_phenotype"
+                ]
+              },
+              "e2": {
+                "subject": "n2",
+                "object": "n3",
+                "predicates": [
+                    "biolink:affects_expression_of"
+                ]
+              },
+              "eA": {
+                "subject": "n3",
+                "object": "n4",
+                "predicates": [
+                    "biolink:has_phenotype"
+                ]
+              },
+              "eB": {
+                "subject": "n0",
+                "object": "n4",
+                "predicates": [
+                    "biolink:related_to"
+                ]
+              }
+        }
+      }
+    }
+  }

--- a/tests/test_jsons/test_merge_qedges_success.json
+++ b/tests/test_jsons/test_merge_qedges_success.json
@@ -1,45 +1,38 @@
 {
-    "message": {
-      "query_graph": {
-        "nodes": {},
-        "edges": {
-            "e0": {
-                "subject": "n0",
-                "object": "n1",
-                "predicates": [
-                  "biolink:related_to"
-                ]
-              },
-              "e1": {
-                "subject": "n1",
-                "object": "n2",
-                "predicates": [
-                    "biolink:affects_abundance_of",
-                    "biolink:has_phenotype"
-                ]
-              },
-              "e2": {
-                "subject": "n2",
-                "object": "n3",
-                "predicates": [
-                    "biolink:affects_expression_of"
-                ]
-              },
-              "eA": {
-                "subject": "n3",
-                "object": "n4",
-                "predicates": [
-                    "biolink:has_phenotype"
-                ]
-              },
-              "eB": {
-                "subject": "n0",
-                "object": "n4",
-                "predicates": [
-                    "biolink:related_to"
-                ]
-              }
-        }
-      }
+    "e0": {
+        "subject": "n0",
+        "object": "n1",
+        "predicates": [
+            "biolink:related_to"
+        ]
+    },
+    "e1": {
+        "subject": "n1",
+        "object": "n2",
+        "predicates": [
+            "biolink:affects_abundance_of",
+            "biolink:has_phenotype"
+        ]
+    },
+    "e2": {
+        "subject": "n2",
+        "object": "n3",
+        "predicates": [
+            "biolink:affects_expression_of"
+        ]
+    },
+    "eA": {
+        "subject": "n3",
+        "object": "n4",
+        "predicates": [
+            "biolink:has_phenotype"
+        ]
+    },
+    "eB": {
+        "subject": "n0",
+        "object": "n4",
+        "predicates": [
+            "biolink:related_to"
+        ]
     }
-  }
+}

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -1,5 +1,8 @@
 """Test merging."""
+import json
+
 from reasoner_util import merge_categories, merge_ids
+from reasoner_util import merge_qedges
 
 from .util import unordered_lists_equal
 
@@ -40,3 +43,18 @@ def test_merge_categories():
             "biolink:DiseaseOrPhenotypicFeature",
         ],
     )
+
+
+def test_merge_qedges():
+    """Test merge_qedges"""
+    with open("tests/test_jsons/test_merge_qedges1.json", "r") as file:
+        message_dict1 = json.load(file)
+    with open("tests/test_jsons/test_merge_qedges2.json", "r") as file:
+        message_dict2 = json.load(file)
+
+    merged_message_dict = merge_qedges(message_dict1, message_dict2)
+
+    with open("tests/test_jsons/test_merge_qedges_success.json", "r") as file:
+        correct_merged_message_dict = json.load(file)
+
+    assert merged_message_dict == correct_merged_message_dict

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -1,5 +1,6 @@
 """Test merging."""
 import json
+import pytest
 
 from reasoner_util import merge_categories, merge_ids
 from reasoner_util import merge_qedges
@@ -58,3 +59,14 @@ def test_merge_qedges():
         correct_merged_qedges = json.load(file)
 
     assert merged_qedges == correct_merged_qedges
+
+
+def test_merge_qedges_error():
+    """Test merge_qedges"""
+    with open("tests/test_jsons/test_merge_qedges1.json", "r") as file:
+        qedges1 = json.load(file)
+    with open("tests/test_jsons/test_merge_qedges2_w_error.json", "r") as file:
+        qedges2 = json.load(file)
+
+    with pytest.raises(ValueError):
+        merge_qedges(qedges1, qedges2)

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -48,13 +48,13 @@ def test_merge_categories():
 def test_merge_qedges():
     """Test merge_qedges"""
     with open("tests/test_jsons/test_merge_qedges1.json", "r") as file:
-        message_dict1 = json.load(file)
+        qedges1 = json.load(file)
     with open("tests/test_jsons/test_merge_qedges2.json", "r") as file:
-        message_dict2 = json.load(file)
+        qedges2 = json.load(file)
 
-    merged_message_dict = merge_qedges(message_dict1, message_dict2)
+    merged_qedges = merge_qedges(qedges1, qedges2)
 
     with open("tests/test_jsons/test_merge_qedges_success.json", "r") as file:
-        correct_merged_message_dict = json.load(file)
+        correct_merged_qedges = json.load(file)
 
-    assert merged_message_dict == correct_merged_message_dict
+    assert merged_qedges == correct_merged_qedges


### PR DESCRIPTION
Create a function that merges query graph edges. For two qedges (e.g. qedge0 = (key0, value0) and qedge1 = (key1, value1)) to be equivalent, the edge keys must be equal (key0 = key1) and their values must be equal (value0 = value1). If there are equivalent edges between the two query graphs, they will be merged. If an edge key is unique to one of the queries, then such an edge will be concatenated to the "edges" dictionary in the resultant merged message.