### PR TITLE
Merge qnodes

### DIFF
--- a/reasoner_util/__init__.py
+++ b/reasoner_util/__init__.py
@@ -171,3 +171,17 @@ def merge_qedges(qedges1: dict, qedges2: dict) -> dict:
         elif qedge_value != new_edges[qedge_key]:
             raise ValueError("Key exists in both messages but values do not match.")
     return new_edges
+
+
+def merge_qnodes(qnodes1: dict, qnodes2: dict) -> dict:
+    """Merge qnodes: the keys must be the same and the values must be the same.
+    If a key is unique to one nodes dict, then the node will be concatenated to
+    the new nodes dictionary. If a particular key exists in both messages but
+    the values do not match, this will result in an error. """
+    new_nodes = copy.deepcopy(qnodes1)
+    for qnode_key, qnode_value in qnodes2.items():
+        if qnode_key not in new_nodes:
+            new_nodes[qnode_key] = copy.deepcopy(qnode_value)
+        elif qnode_value != new_nodes[qnode_key]:
+            raise ValueError("Key exists in both messages but values do not match.")
+    return new_nodes

--- a/tests/test_jsons/test_merge_qnodes1.json
+++ b/tests/test_jsons/test_merge_qnodes1.json
@@ -1,0 +1,34 @@
+{
+    "n0": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "CHEBI:23639"
+        ]
+    },
+    "n1": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0005010"
+        ]
+    },
+    "n2": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0024613"
+        ]
+    },
+    "nA": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0005618"
+        ]
+    }
+}

--- a/tests/test_jsons/test_merge_qnodes2.json
+++ b/tests/test_jsons/test_merge_qnodes2.json
@@ -1,0 +1,34 @@
+{
+    "n0": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "CHEBI:23639"
+        ]
+    },
+    "n1": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0005010"
+        ]
+    },
+    "n2": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0024613"
+        ]
+    },
+    "nB": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "EFO:1001454"
+        ]
+    }
+}

--- a/tests/test_jsons/test_merge_qnodes2_w_error.json
+++ b/tests/test_jsons/test_merge_qnodes2_w_error.json
@@ -1,0 +1,34 @@
+{
+    "n0": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "CHEBI:23639"
+        ]
+    },
+    "n1": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0021107"
+        ]
+    },
+    "n2": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0024613"
+        ]
+    },
+    "nB": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "EFO:1001454"
+        ]
+    }
+}

--- a/tests/test_jsons/test_merge_qnodes_success.json
+++ b/tests/test_jsons/test_merge_qnodes_success.json
@@ -1,0 +1,42 @@
+{
+    "n0": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "CHEBI:23639"
+        ]
+    },
+    "n1": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0005010"
+        ]
+    },
+    "n2": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0024613"
+        ]
+    },
+    "nA": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "MONDO:0005618"
+        ]
+    },
+    "nB": {
+        "categories": [
+            "biolink:Entity"
+        ],
+        "ids": [
+            "EFO:1001454"
+        ]
+    }
+}

--- a/tests/test_merging.py
+++ b/tests/test_merging.py
@@ -2,8 +2,8 @@
 import json
 import pytest
 
-from reasoner_util import merge_categories, merge_ids
-from reasoner_util import merge_qedges
+from reasoner_util import (merge_categories, merge_ids, merge_qedges,
+                           merge_qnodes)
 
 from .util import unordered_lists_equal
 
@@ -70,3 +70,29 @@ def test_merge_qedges_error():
 
     with pytest.raises(ValueError):
         merge_qedges(qedges1, qedges2)
+
+
+def test_merge_qnodes():
+    """Test merge_qnodes"""
+    with open("tests/test_jsons/test_merge_qnodes1.json", "r") as file:
+        qnodes1 = json.load(file)
+    with open("tests/test_jsons/test_merge_qnodes2.json", "r") as file:
+        qnodes2 = json.load(file)
+
+    merged_qnodes = merge_qnodes(qnodes1, qnodes2)
+
+    with open("tests/test_jsons/test_merge_qnodes_success.json", "r") as file:
+        correct_merged_qnodes = json.load(file)
+
+    assert merged_qnodes == correct_merged_qnodes
+
+
+def test_merge_qnodes_error():
+    """Test merge_qnodes"""
+    with open("tests/test_jsons/test_merge_qnodes1.json", "r") as file:
+        qnodes1 = json.load(file)
+    with open("tests/test_jsons/test_merge_qnodes2_w_error.json", "r") as file:
+        qnodes2 = json.load(file)
+
+    with pytest.raises(ValueError):
+        merge_qnodes(qnodes1, qnodes2)


### PR DESCRIPTION
Merge qnodes is similar to merge qedges. The keys must be the same and the values must be the same. If a key is unique to one nodes dict, then the node will be concatenated to the new nodes dictionary. If a particular key exists in both messages but the values do not match, this will result in an error.